### PR TITLE
feat: add support for html strings

### DIFF
--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -1,8 +1,9 @@
+import { isValidUrl } from "../util/helpers";
+
 export const checkValidUrl = (req: any, res: any, next: Function) => {
   const { url } = req.query;
-  const validUrlPattern = /^(http|https):\/\//;
   try {
-    if (!validUrlPattern.test(url)) {
+    if (!isValidUrl(url)) {
       console.log("[Middleware] Invalid url received", { url });
       throw "Invalid url protocol. Expected url to have protocol, https:// or http://";
     }

--- a/server.ts
+++ b/server.ts
@@ -13,7 +13,6 @@ import {
   handleSendFileCallback,
 } from "./util/helpers";
 
-import { checkValidUrl } from "./middleware";
 import { GenerateEndpointQueryParams } from "./util/types";
 
 const PORT = process.env.PORT || 4000;
@@ -41,7 +40,7 @@ app.get("/template/:name", (req, res) => {
   res.render(`templates/${templateName}`, data);
 });
 
-app.get("/generate", checkValidUrl, async (req, res) => {
+app.get("/generate", async (req, res) => {
   try {
     const reqQuery = {
       ...DEFAULT_GENERATE_ENDPOINT_QUERY,
@@ -55,7 +54,7 @@ app.get("/generate", checkValidUrl, async (req, res) => {
     const fileGenerator = getFileGenerator();
     const { filename, absoluteFilePath } = await generateFile(
       fileGenerator,
-      reqQuery,
+      reqQuery as GenerateEndpointQueryParams,
       DUMP_DIRECTORY
     );
 

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -6,6 +6,7 @@ import {
   ensureFileExtension,
   buildQueryString,
   appendQueryString,
+  isValidUrl,
 } from "../util/helpers";
 
 describe("deleteFile", () => {
@@ -109,5 +110,17 @@ describe("appendQueryString", () => {
 
     const finalUrl = appendQueryString(url, "");
     expect(finalUrl).toBe(url);
+  });
+});
+
+describe("isValidUrl", () => {
+  it("should return true on valid url", () => {
+    const validUrl = "https://www.google.com";
+    expect(isValidUrl(validUrl)).toBe(true);
+  });
+
+  it("should return false on invalid url", () => {
+    const invalidUrl = "www.google.com";
+    expect(isValidUrl(invalidUrl)).toBe(false);
   });
 });

--- a/util/types.ts
+++ b/util/types.ts
@@ -8,20 +8,22 @@ export interface GeneratorPdfOptions {}
 
 export interface HtmlToFileGenerator {
   generateImage(
-    url: string,
+    source: string,
+    sourceKind: HtmlSourceKind,
     destination: string,
     options?: GeneratorImageOptions
   ): Promise<string>;
 
   generatePdf(
-    url: string,
+    source: string,
     destination: string,
     options?: GeneratorPdfOptions
   ): Promise<string>;
 }
 
 export type GeneratorParams = {
-  url: string;
+  url?: string;
+  html?: string;
   type: "image" | "pdf";
   selector: string;
   height?: number;
@@ -35,3 +37,5 @@ export interface GenerateEndpointQueryParams extends GeneratorParams {
   autoRegenerate?: string;
   fallbackUrl?: string;
 }
+
+export type HtmlSourceKind = "url" | "html";


### PR DESCRIPTION
# Changes in this PR
- This PR adds support for file generation using HTML strings
- This can be done with the following endpoint if running locally: `http://localhost:4000/generate?html=<h1>hello</h1>`
- In testing this I noticed that file names became too long when using HTML strings since the entire HTML content is encrypted in the file name. To prevent this issue, the HTML string is not used in the filename and so files created using HTML are not auto-regenerable

# Next Steps
- Add a database (MongoDB) to store file generation details in case users opt-in for the file to be auto-regenerable
- Optionally persist files in the database instead for a limited time period.