### PR TITLE
test: add integration tests

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,0 +1,25 @@
+import * as express from "express";
+import * as cors from "cors";
+
+import { appRoutes } from "./routes";
+
+const app = express();
+app.set("view engine", "ejs");
+
+app.use(cors({ origin: true, credentials: true }));
+app.use(express.json());
+
+app.get("/health", (req, res) => {
+  try {
+    res.send({
+      message: "Up and running!",
+      success: true,
+    });
+  } catch (error) {
+    res.status(400).send({ error: "Currently unavailable" });
+  }
+});
+
+app.use(appRoutes);
+
+export { app };

--- a/package-lock.json
+++ b/package-lock.json
@@ -961,6 +961,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+      "dev": true
+    },
     "@types/cors": {
       "version": "2.8.10",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
@@ -1206,6 +1212,25 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "@types/superagent": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.12.tgz",
+      "integrity": "sha512-1GQvD6sySQPD6p9EopDFI3f5OogdICl1sU/2ij3Esobz/RtL9fWZZDPmsuv7eiy5ya+XNiPAxUcI3HIUTJa+3A==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/supertest": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.11.tgz",
+      "integrity": "sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==",
+      "dev": true,
+      "requires": {
+        "@types/superagent": "*"
+      }
     },
     "@types/yargs": {
       "version": "16.0.3",
@@ -1589,6 +1614,16 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1691,6 +1726,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1727,6 +1768,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
     },
     "cors": {
       "version": "2.8.5",
@@ -2103,6 +2150,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
+      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==",
+      "dev": true
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -2171,6 +2224,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -2215,6 +2274,17 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -2268,6 +2338,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -4138,6 +4214,12 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-inspect": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4544,6 +4626,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -4660,6 +4753,76 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
+    },
+    "superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "supertest": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.5.tgz",
+      "integrity": "sha512-Is3pFB2TxSFPohDS2tIM8h2JOMvUQwbJ9TvTfsWAm89ZZv1CF4VTLAsQz+5+5S1wOgaMqFqSpFriU15L3e2AXQ==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^6.1.0"
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "server.js",
   "scripts": {
     "postinstall": "npm run build",
-    "test": "jest",
+    "test": "NODE_PATH=$PWD jest",
     "coverage": "jest --coverage",
     "build": "tsc",
-    "start": "node ./dist/server/server.js",
-    "dev": "nodemon"
+    "start": "NODE_PATH=$PWD node ./dist/server/server.js",
+    "dev": "NODE_PATH=$PWD nodemon"
   },
   "author": "Rexford Essilfie",
   "license": "ISC",
@@ -29,7 +29,9 @@
     "@types/express": "^4.17.9",
     "@types/jest": "^26.0.23",
     "@types/puppeteer": "^5.4.2",
+    "@types/supertest": "^2.0.11",
     "jest": "^27.0.3",
+    "supertest": "^6.1.5",
     "ts-jest": "^27.0.2",
     "typescript": "^4.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "postinstall": "npm run build",
-    "test": "NODE_PATH=$PWD jest",
+    "test": "jest",
     "coverage": "jest --coverage",
     "build": "tsc",
     "start": "NODE_PATH=$PWD node ./dist/server/server.js",

--- a/routes/file.routes.ts
+++ b/routes/file.routes.ts
@@ -1,0 +1,40 @@
+import * as express from "express";
+import * as path from "path";
+
+import { DUMP_DIRECTORY } from "../util/constants";
+import {
+  deleteFileAfterTimeout,
+  handleSendFileCallback,
+} from "../util/helpers";
+
+const router = express.Router();
+
+router.get("/resource/:name", (req, res) => {
+  const name = req.params.name as string;
+  const filePath = path.resolve(DUMP_DIRECTORY, name);
+  try {
+    res.sendFile(filePath, (error) => {
+      handleSendFileCallback(req, res, error, "resource");
+    });
+    // Delete file after sending to client
+    deleteFileAfterTimeout(filePath, 1000);
+  } catch (error) {
+    res.status(400).send({ error: error.message });
+  }
+});
+
+router.get("/download/:name", (req, res) => {
+  const name = req.params.name as string;
+  const filePath = path.resolve(DUMP_DIRECTORY, name);
+  try {
+    res.download(filePath, (error) => {
+      handleSendFileCallback(req, res, error, "download");
+    });
+    // Delete file after sending to client
+    deleteFileAfterTimeout(filePath, 1000);
+  } catch (error) {
+    res.status(400).send({ error: error.message });
+  }
+});
+
+export { router };

--- a/routes/generate.routes.ts
+++ b/routes/generate.routes.ts
@@ -1,0 +1,76 @@
+import * as express from "express";
+import * as fs from "fs";
+
+import {
+  DEFAULT_GENERATE_ENDPOINT_QUERY,
+  DUMP_DIRECTORY,
+  PUBLIC_URL,
+} from "../util/constants";
+
+import {
+  appendQueryString,
+  buildQueryString,
+  deleteFileAfterTimeout,
+  ensureDirectoryExists,
+  generateFile,
+  getFileGenerator,
+} from "../util/helpers";
+import { GenerateEndpointQueryParams } from "../util/types";
+
+const router = express.Router();
+
+router.get("/", async (req, res) => {
+  try {
+    const reqQuery = {
+      ...DEFAULT_GENERATE_ENDPOINT_QUERY,
+      ...req.query,
+    };
+
+    const { responseKind = "json" } = reqQuery;
+
+    ensureDirectoryExists(DUMP_DIRECTORY);
+
+    const fileGenerator = getFileGenerator();
+    const { filename, absoluteFilePath } = await generateFile(
+      fileGenerator,
+      reqQuery as GenerateEndpointQueryParams,
+      DUMP_DIRECTORY
+    );
+
+    deleteFileAfterTimeout(absoluteFilePath, 30000); // delete file after 30 seconds
+
+    const internalResourcePath = `/file/resource/${filename}`;
+    const internalDownloadPath = `/file/download/${filename}`;
+
+    if (responseKind === "resource") {
+      res.redirect(internalResourcePath);
+    } else if (responseKind === "download") {
+      res.redirect(internalDownloadPath);
+    } else if (responseKind === "buffer") {
+      const buffer = fs.readFileSync(absoluteFilePath);
+      res.send({ buffer });
+    } else {
+      // Respond with JSON object
+      const { fallbackUrl } = reqQuery;
+      const finalQueryString = buildQueryString({ fallbackUrl });
+      const _resourceLink = `${PUBLIC_URL}${internalResourcePath}`;
+      const _downloadLink = `${PUBLIC_URL}${internalDownloadPath}`;
+
+      const resourceLink = appendQueryString(_resourceLink, finalQueryString);
+      const downloadLink = appendQueryString(_downloadLink, finalQueryString);
+
+      res.send({
+        success: true,
+        message: "File successfully generated!",
+        resourceLink,
+        downloadLink,
+      });
+    }
+  } catch (error) {
+    res
+      .status(400)
+      .send({ success: false, message: "An error occurred: " + error });
+  }
+});
+
+export { router };

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -1,0 +1,12 @@
+import * as express from "express";
+import { router as generateRoutes } from "./generate.routes";
+import { router as fileRoutes } from "./file.routes";
+import { router as templateRoutes } from "./template.routes";
+
+const appRoutes = express.Router();
+
+appRoutes.use("/file", fileRoutes);
+appRoutes.use("/template", templateRoutes);
+appRoutes.use("/generate", generateRoutes);
+
+export { appRoutes, fileRoutes, templateRoutes, generateRoutes };

--- a/routes/template.routes.ts
+++ b/routes/template.routes.ts
@@ -1,0 +1,13 @@
+import * as express from "express";
+import { PUBLIC_URL } from "../util/constants";
+
+const router = express.Router();
+
+router.get("/:name", (req, res) => {
+  const templateName = req.params.name as string;
+  const { fallbackUrl = "" } = req.query;
+  const data = { fallbackUrl, baseUrl: PUBLIC_URL };
+  res.render(`../templates/${templateName}`, data);
+});
+
+export { router };

--- a/server.ts
+++ b/server.ts
@@ -1,126 +1,14 @@
 import * as express from "express";
-import * as path from "path";
 import * as cors from "cors";
-import * as fs from "fs";
 
-import {
-  appendQueryString,
-  buildQueryString,
-  deleteFileAfterTimeout,
-  ensureDirectoryExists,
-  generateFile,
-  getFileGenerator,
-  handleSendFileCallback,
-} from "./util/helpers";
-
-import { GenerateEndpointQueryParams } from "./util/types";
-
-const PORT = process.env.PORT || 4000;
-const DUMP_DIRECTORY = path.resolve("./temp");
-const PUBLIC_URL =
-  process.env.NODE_ENV === "production"
-    ? process.env.PUBLIC_URL
-    : `http://localhost:${PORT}`;
-
-const DEFAULT_GENERATE_ENDPOINT_QUERY: Partial<GenerateEndpointQueryParams> = {
-  responseKind: "json",
-  autoRegenerate: "true",
-  fallbackUrl: "",
-};
+import { appRoutes } from "./routes";
+import { PORT } from "./util/constants";
 
 const app = express();
 app.set("view engine", "ejs");
+
 app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
-
-app.get("/template/:name", (req, res) => {
-  const templateName = req.params.name as string;
-  const { fallbackUrl = "" } = req.query;
-  const data = { fallbackUrl, baseUrl: PUBLIC_URL };
-  res.render(`templates/${templateName}`, data);
-});
-
-app.get("/generate", async (req, res) => {
-  try {
-    const reqQuery = {
-      ...DEFAULT_GENERATE_ENDPOINT_QUERY,
-      ...req.query,
-    };
-
-    const { responseKind = "json" } = reqQuery;
-
-    ensureDirectoryExists(DUMP_DIRECTORY);
-
-    const fileGenerator = getFileGenerator();
-    const { filename, absoluteFilePath } = await generateFile(
-      fileGenerator,
-      reqQuery as GenerateEndpointQueryParams,
-      DUMP_DIRECTORY
-    );
-
-    deleteFileAfterTimeout(absoluteFilePath, 30000); // delete file after 30 seconds
-
-    const internalResourcePath = `/resources/${filename}`;
-    const internalDownloadPath = `/downloads/${filename}`;
-
-    if (responseKind === "resource") {
-      res.redirect(internalResourcePath);
-    } else if (responseKind === "download") {
-      res.redirect(internalDownloadPath);
-    } else if (responseKind === "buffer") {
-      const buffer = fs.readFileSync(absoluteFilePath);
-      res.send({ buffer });
-    } else {
-      // Respond with JSON object
-      const { fallbackUrl } = reqQuery;
-      const finalQueryString = buildQueryString({ fallbackUrl });
-      const _resourceLink = `${PUBLIC_URL}${internalResourcePath}`;
-      const _downloadLink = `${PUBLIC_URL}${internalDownloadPath}`;
-
-      const resourceLink = appendQueryString(_resourceLink, finalQueryString);
-      const downloadLink = appendQueryString(_downloadLink, finalQueryString);
-
-      res.send({
-        success: true,
-        message: "File successfully generated!",
-        resourceLink,
-        downloadLink,
-      });
-    }
-  } catch (error) {
-    res
-      .status(400)
-      .send({ success: false, message: "An error occurred: " + error });
-  }
-});
-
-app.get("/resources/:name", (req, res) => {
-  const name = req.params.name as string;
-  const filePath = path.resolve(DUMP_DIRECTORY, name);
-  try {
-    res.sendFile(filePath, (error) => {
-      handleSendFileCallback(req, res, error, "resource");
-    });
-    // Delete file after sending to client
-    deleteFileAfterTimeout(filePath, 1000);
-  } catch (error) {
-    res.status(400).send({ error: error.message });
-  }
-});
-
-app.get("/downloads/:name", (req, res) => {
-  const name = req.params.name as string;
-  const filePath = path.resolve(DUMP_DIRECTORY, name);
-  try {
-    res.download(filePath, (error) => {
-      handleSendFileCallback(req, res, error, "download");
-    });
-    // Delete file after sending to client
-    deleteFileAfterTimeout(filePath, 1000);
-  } catch (error) {
-    res.status(400).send({ error: error.message });
-  }
-});
 
 app.get("/health", (req, res) => {
   try {
@@ -132,6 +20,8 @@ app.get("/health", (req, res) => {
     res.status(400).send({ error: "Currently unavailable" });
   }
 });
+
+app.use(appRoutes);
 
 try {
   app.listen(PORT, () => {

--- a/server.ts
+++ b/server.ts
@@ -1,27 +1,5 @@
-import * as express from "express";
-import * as cors from "cors";
-
-import { appRoutes } from "./routes";
+import { app } from "./app";
 import { PORT } from "./util/constants";
-
-const app = express();
-app.set("view engine", "ejs");
-
-app.use(cors({ origin: true, credentials: true }));
-app.use(express.json());
-
-app.get("/health", (req, res) => {
-  try {
-    res.send({
-      message: "Up and running!",
-      success: true,
-    });
-  } catch (error) {
-    res.status(400).send({ error: "Currently unavailable" });
-  }
-});
-
-app.use(appRoutes);
 
 try {
   app.listen(PORT, () => {

--- a/tests/integration/generate.routes.test.ts
+++ b/tests/integration/generate.routes.test.ts
@@ -2,6 +2,20 @@ import * as request from "supertest";
 import { PORT } from "../../util/constants";
 import { app as testApp } from "../../app";
 
+import "../../util/helpers";
+
+jest.mock("../../util/helpers", () => {
+  // Mock deleteFileAfterTimeout to delete files immediately
+  jest.unmock("../../util/helpers");
+  const actualHelpers = jest.requireActual("../../util/helpers");
+  console.log(actualHelpers);
+  return {
+    ...jest.requireActual("../../util/helpers"),
+    deleteFileAfterTimeout: jest.fn(() => {
+      actualHelpers.deleteFile();
+    }),
+  };
+});
 describe("test-generate-routes", () => {
   it("GET /generate - should generate pdf given valid url", async () => {
     const { body } = await request(testApp).get(

--- a/tests/integration/generate.routes.test.ts
+++ b/tests/integration/generate.routes.test.ts
@@ -1,15 +1,11 @@
-import { setupTestApp } from "./setup";
 import * as request from "supertest";
-import * as fs from "fs";
-import * as path from "path";
 import { PORT } from "../../util/constants";
+import { app as testApp } from "../../app";
 
 describe("test-generate-routes", () => {
-  const testApp = setupTestApp();
-
   it("GET /generate - should generate pdf given valid url", async () => {
     const { body } = await request(testApp).get(
-      "/generate?url=https://www.google.com&type=pdf"
+      "/generate?url=https://www.google.com"
     );
     // Check that relevant information was returned
     expect(body).toHaveProperty("resourceLink");

--- a/tests/integration/generate.routes.test.ts
+++ b/tests/integration/generate.routes.test.ts
@@ -4,6 +4,9 @@ import { app as testApp } from "../../app";
 
 import "../../util/helpers";
 
+// Test timeout to 10s to prevent failure because of timeout
+jest.setTimeout(10000);
+
 jest.mock("../../util/helpers", () => {
   // Mock deleteFileAfterTimeout to delete files immediately
   jest.unmock("../../util/helpers");

--- a/tests/integration/generate.routes.test.ts
+++ b/tests/integration/generate.routes.test.ts
@@ -8,7 +8,6 @@ jest.mock("../../util/helpers", () => {
   // Mock deleteFileAfterTimeout to delete files immediately
   jest.unmock("../../util/helpers");
   const actualHelpers = jest.requireActual("../../util/helpers");
-  console.log(actualHelpers);
   return {
     ...jest.requireActual("../../util/helpers"),
     deleteFileAfterTimeout: jest.fn(() => {

--- a/tests/integration/generate.routes.test.ts
+++ b/tests/integration/generate.routes.test.ts
@@ -4,9 +4,6 @@ import { app as testApp } from "../../app";
 
 import "../../util/helpers";
 
-// Test timeout to 10s to prevent failure because of timeout
-jest.setTimeout(10000);
-
 jest.mock("../../util/helpers", () => {
   // Mock deleteFileAfterTimeout to delete files immediately
   jest.unmock("../../util/helpers");
@@ -18,6 +15,7 @@ jest.mock("../../util/helpers", () => {
     }),
   };
 });
+
 describe("test-generate-routes", () => {
   it("GET /generate - should generate pdf given valid url", async () => {
     const { body } = await request(testApp).get(

--- a/tests/integration/generate.routes.test.ts
+++ b/tests/integration/generate.routes.test.ts
@@ -1,0 +1,57 @@
+import { setupTestApp } from "./setup";
+import * as request from "supertest";
+import * as fs from "fs";
+import * as path from "path";
+import { PORT } from "../../util/constants";
+
+describe("test-generate-routes", () => {
+  const testApp = setupTestApp();
+
+  it("GET /generate - should generate pdf given valid url", async () => {
+    const { body } = await request(testApp).get(
+      "/generate?url=https://www.google.com&type=pdf"
+    );
+    // Check that relevant information was returned
+    expect(body).toHaveProperty("resourceLink");
+    expect(body).toHaveProperty("downloadLink");
+    expect(body).toHaveProperty("success");
+
+    // Check that the file links are correct
+    const fileLinkRe = new RegExp(
+      `http://localhost:${PORT}/file/\(resource\|download\)/\.\*`
+    );
+
+    expect(fileLinkRe.test(body.resourceLink)).toBeTruthy();
+    expect(fileLinkRe.test(body.downloadLink)).toBeTruthy();
+
+    // TODO: Also check that the file was generated.
+    // Will be easier once files are uploaded to a database instead of file system
+  });
+
+  it("GET /generate - should generate image given valid html string", async () => {
+    const { body } = await request(testApp).get(
+      "/generate?html=<h1>hello</h1>"
+    );
+
+    // Check that relevant information was returned
+    expect(body).toHaveProperty("resourceLink");
+    expect(body).toHaveProperty("downloadLink");
+    expect(body).toHaveProperty("success");
+
+    // Check that the file links are correct
+    const fileLinkRe = new RegExp(
+      `http://localhost:${PORT}/file/\(resource\|download\)/\.\*`
+    );
+
+    expect(fileLinkRe.test(body.resourceLink)).toBeTruthy();
+    expect(fileLinkRe.test(body.downloadLink)).toBeTruthy();
+
+    // TODO: Also check that the file was generated.
+    // Will be easier once files are uploaded to a database instead of file system
+  });
+
+  it("GET /generate - should throw on invalid request", async () => {
+    // Invalid request since no url or html string
+    await request(testApp).get("/generate").expect(400);
+  });
+});

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,0 +1,8 @@
+import * as express from "express";
+import { appRoutes } from "../../routes";
+
+export const setupTestApp = () => {
+  const app = express();
+  app.use(appRoutes);
+  return app;
+};

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -1,0 +1,20 @@
+import * as path from "path";
+
+import { GenerateEndpointQueryParams } from "../util/types";
+
+// Environment-based constants
+export const ROOT_DIR = process.env.NODE_PATH || "../";
+export const PORT = process.env.PORT || 4000;
+export const PUBLIC_URL =
+  process.env.NODE_ENV === "production"
+    ? process.env.PUBLIC_URL
+    : `http://localhost:${PORT}`;
+
+// Regular constants
+export const DUMP_DIRECTORY = path.resolve(ROOT_DIR, "temp");
+export const DEFAULT_GENERATE_ENDPOINT_QUERY: Partial<GenerateEndpointQueryParams> =
+  {
+    responseKind: "json",
+    autoRegenerate: "true",
+    fallbackUrl: "",
+  };

--- a/util/generators.ts
+++ b/util/generators.ts
@@ -29,6 +29,7 @@ export class PuppeteerGeneratorSingleton implements HtmlToFileGenerator {
     PuppeteerGeneratorSingleton.browser = await puppeteer.launch({
       // should allow puppeteer to work in heroku
       args: ["--no-sandbox", "--disable-setuid-sandbox"],
+      headless: true,
     });
   }
 

--- a/util/generators.ts
+++ b/util/generators.ts
@@ -97,7 +97,7 @@ export class PuppeteerGeneratorSingleton implements HtmlToFileGenerator {
     const allPagesClosed = openPages.length == 0;
 
     if (allPagesClosed) {
-      PuppeteerGeneratorSingleton.tearDown();
+      await PuppeteerGeneratorSingleton.tearDown();
     }
   }
 

--- a/util/generators.ts
+++ b/util/generators.ts
@@ -14,14 +14,18 @@ export class PuppeteerGeneratorSingleton implements HtmlToFileGenerator {
   static pages = {} as Record<string, puppeteer.Page | null | undefined>;
 
   constructor() {
-    if (!PuppeteerGeneratorSingleton.browser) {
-      PuppeteerGeneratorSingleton.setUp();
+    if (!PuppeteerGeneratorSingleton._instance) {
       PuppeteerGeneratorSingleton._instance = this;
     }
     return PuppeteerGeneratorSingleton._instance;
   }
 
-  static async setUp() {
+  static async setUpBrowser() {
+    // TODO: manage multiple browsers
+    if (PuppeteerGeneratorSingleton.browser) {
+      return;
+    }
+
     PuppeteerGeneratorSingleton.browser = await puppeteer.launch({
       // should allow puppeteer to work in heroku
       args: ["--no-sandbox", "--disable-setuid-sandbox"],
@@ -48,6 +52,7 @@ export class PuppeteerGeneratorSingleton implements HtmlToFileGenerator {
     PuppeteerGeneratorSingleton.pages[pageId] = null;
 
     try {
+      await PuppeteerGeneratorSingleton.setUpBrowser();
       const page = await PuppeteerGeneratorSingleton.browser?.newPage();
 
       if (sourceKind == "url") {
@@ -66,14 +71,32 @@ export class PuppeteerGeneratorSingleton implements HtmlToFileGenerator {
   }
 
   /** Closes the browser page. (currently not in use since closing sometimes causes navigation errors) */
-  static async closeBrowserPage(pageId: string) {
+  static async closeBrowserPage(pageId: string | null) {
+    if (!pageId) {
+      return;
+    }
+
     const pageToClose = PuppeteerGeneratorSingleton.pages[pageId];
+
     if (pageToClose) {
       await pageToClose.close();
       PuppeteerGeneratorSingleton.pages[pageId] = null;
       console.log(`[PuppeteerGenerator] Closing browser page`, {
         pageId,
       });
+    }
+
+    await PuppeteerGeneratorSingleton.tearDownBrowserIfInactive();
+  }
+
+  static async tearDownBrowserIfInactive() {
+    const openPages = Object.values(PuppeteerGeneratorSingleton.pages).filter(
+      (page) => !!page
+    );
+    const allPagesClosed = openPages.length == 0;
+
+    if (allPagesClosed) {
+      PuppeteerGeneratorSingleton.tearDown();
     }
   }
 
@@ -83,10 +106,11 @@ export class PuppeteerGeneratorSingleton implements HtmlToFileGenerator {
     filename: string,
     options: any = {}
   ): Promise<string> {
+    let pageId = null;
     console.log("[PuppeteerGenerator] About to generate image...");
     const fileWithExtension = ensureFileExtension(filename, "png");
     try {
-      const pageId = await PuppeteerGeneratorSingleton.loadBrowserPage(
+      pageId = await PuppeteerGeneratorSingleton.loadBrowserPage(
         source,
         sourceKind
       );
@@ -99,10 +123,11 @@ export class PuppeteerGeneratorSingleton implements HtmlToFileGenerator {
       console.log("[PuppeteerGenerator] Done generating image", {
         fileWithExtension,
       });
-      await PuppeteerGeneratorSingleton.closeBrowserPage(pageId);
       return fileWithExtension;
     } catch (error) {
       throw error;
+    } finally {
+      await PuppeteerGeneratorSingleton.closeBrowserPage(pageId);
     }
   }
 
@@ -112,10 +137,11 @@ export class PuppeteerGeneratorSingleton implements HtmlToFileGenerator {
     filename: string,
     options: any = {}
   ): Promise<string> {
+    let pageId = null;
     console.log("[PuppeteerGenerator] About to generate pdf...");
     const fileWithExtension = ensureFileExtension(filename, "pdf");
     try {
-      const pageId = await PuppeteerGeneratorSingleton.loadBrowserPage(
+      pageId = await PuppeteerGeneratorSingleton.loadBrowserPage(
         source,
         sourceKind
       );
@@ -126,9 +152,12 @@ export class PuppeteerGeneratorSingleton implements HtmlToFileGenerator {
       });
       console.log("[PuppeteerGenerator] Done generating pdf."),
         { fileWithExtension };
+
       return fileWithExtension;
     } catch (error) {
       throw error;
+    } finally {
+      await PuppeteerGeneratorSingleton.closeBrowserPage(pageId);
     }
   }
 


### PR DESCRIPTION
# Changes in this PR
- Adds integration testing for `/generate` endpoint
- To support integration testing, routes have been refactored into separate router files.
- The main express app logic has also been separated from the call to listen for the browser

# TODO
- Add database support to prevent overly long file names